### PR TITLE
fix(lib): display c frequency only when is defined to avoid confusion

### DIFF
--- a/canlib/generators/lib/c/network.h.j2
+++ b/canlib/generators/lib/c/network.h.j2
@@ -77,7 +77,7 @@ typedef struct {
 
 // Frequencies
 
-{% for message in schema.messages %}
+{% for message in schema.messages if message.frequency != -1 %}
 #define {{ network.name }}_{{ message.name }}_FREQUENCY {{ message.frequency }}
 {%- endfor %}
 


### PR DESCRIPTION
If frequency is not defined in the network for that particular message, but it is defined as a macro with a -1 value, there is the possibility that someone could mistakenly use that