### PR TITLE
Fixed return value on index_from_id and id_from_index

### DIFF
--- a/canlib/generators/lib/c/network.h.j2
+++ b/canlib/generators/lib/c/network.h.j2
@@ -347,7 +347,7 @@ static inline int {{ network.name }}_index_from_id(canlib_message_id id) {
 {%- endfor %}
 {%- endfor %}
     }
-    return {{ network.get_message_count() }}; // invalid
+    return -1; // invalid
 }
 
 static inline int {{ network.name }}_id_from_index(int index) {
@@ -358,7 +358,7 @@ static inline int {{ network.name }}_id_from_index(int index) {
 {%- endfor %}
 {%- endfor %}
     }
-    return {{ network.get_message_count() }}; // invalid
+    return -1; // invalid
 }
 
 int {{ network.name }}_fields_from_id(canlib_message_id message_id, char *buffer);


### PR DESCRIPTION
fix(network): index_from_id now return -1 when invalid index (or id)